### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/twilio-fallback/security/code-scanning/1](https://github.com/android-sms-gateway/twilio-fallback/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only needs to read the repository contents (e.g., to check out code and run tests), we will set `contents: read` at the workflow level. This will apply the minimal required permissions to all jobs in the workflow unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
