### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -60,6 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     concurrency: production
+    permissions:
+      contents: read
+      deployments: write
     env:
       DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/twilio-fallback/security/code-scanning/3](https://github.com/android-sms-gateway/twilio-fallback/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `deploy` job that explicitly limits the permissions of the `GITHUB_TOKEN`. Since the `deploy` job only triggers a webhook, it does not require any write permissions. The minimal permissions required are `contents: read`. This change ensures the job adheres to the principle of least privilege and avoids inheriting potentially excessive permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow to specify read and write permissions for deployments.
  - Updated Go workflow to specify read permissions for repository contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->